### PR TITLE
Fix for #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ from there.Additionally, [Gradle](https://gradle.org/) is required to actually u
 GatorGradle. A complete example configuration of Gradle and GatorGradle is available
 in the [Sample Lab](https://github.com/GatorEducator/gatorgrader-samplelab) repository.
 
+NOTE: GatorGradle will automatically install [Pipenv](pipenv.readthedocs.io),
+but does not add the executable to `$PATH`. This can be done manually if the
+user wishes to use Pipenv for other projects.
+
 ## Configuring Checks
 
 The `grade` task reads the configuration provided in `config/gatorgrader.yml`

--- a/src/main/java/org/gatorgradle/command/BasicCommand.java
+++ b/src/main/java/org/gatorgradle/command/BasicCommand.java
@@ -201,8 +201,11 @@ public class BasicCommand implements Command {
       output = out.toString().trim();
 
     } catch (Throwable thr) {
-      Logging.getLogger(BasicCommand.class)
+      //Only log if showing output
+      if (outSys) {
+        Logging.getLogger(BasicCommand.class)
           .error("Exception while running {}: {}", toString(), thr);
+      }
       exitVal = 127;
     } finally {
       fin = true;


### PR DESCRIPTION
This fixes the initial problem of `ensurepip` being disabled on Ubuntu/Debian machines. Additionally, Pipenv installation was improved. Everything should work on a first run to download all dependencies and set up GatorGrader, given Git, python, and pip are installed. I have not tested this on a setup without `pyenv`, so perhaps at some point that can be done on an alden machine.