### PR TITLE
Fix note regarding installation of Pipenv in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ GatorGradle. A complete example configuration of Gradle and GatorGradle is avail
 in the [Sample Lab](https://github.com/GatorEducator/gatorgrader-samplelab) repository.
 
 NOTE: GatorGradle will **NOT** automatically install [Pipenv](https://pipenv.readthedocs.io/en/latest/).
-To install Pipenv please follow [these](https://pipenv.readthedocs.io/en/latest/#install-pipenv-today) instructions.
+To install Pipenv please follow
+[these](https://pipenv.readthedocs.io/en/latest/#install-pipenv-today) instructions.
 
 ## Configuring Checks
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ from there. Additionally, [Gradle](https://gradle.org/) is required to actually 
 GatorGradle. A complete example configuration of Gradle and GatorGradle is available
 in the [Sample Lab](https://github.com/GatorEducator/gatorgrader-samplelab) repository.
 
-NOTE: GatorGradle will automatically install [Pipenv](pipenv.readthedocs.io),
-but does not add the executable to `$PATH`. This can be done manually if the
-user wishes to use Pipenv for other projects.
+NOTE: GatorGradle will automatically **NOT** install [Pipenv](pipenv.readthedocs.io). Nothing other then GatorGradle will be installed automatically.
 
+To install Pipenv please follow [these](https://pipenv.readthedocs.io/en/latest/#install-pipenv-today) instructions.
 ## Configuring Checks
 
 The `grade` task reads the configuration provided in `config/gatorgrader.yml`

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ from there. Additionally, [Gradle](https://gradle.org/) is required to actually 
 GatorGradle. A complete example configuration of Gradle and GatorGradle is available
 in the [Sample Lab](https://github.com/GatorEducator/gatorgrader-samplelab) repository.
 
-NOTE: GatorGradle will **NOT** automatically install [Pipenv](pipenv.readthedocs.io). Nothing other then GatorGradle will be installed automatically.
-
+NOTE: GatorGradle will **NOT** automatically install [Pipenv](https://pipenv.readthedocs.io/en/latest/).
 To install Pipenv please follow [these](https://pipenv.readthedocs.io/en/latest/#install-pipenv-today) instructions.
+
 ## Configuring Checks
 
 The `grade` task reads the configuration provided in `config/gatorgrader.yml`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from there. Additionally, [Gradle](https://gradle.org/) is required to actually 
 GatorGradle. A complete example configuration of Gradle and GatorGradle is available
 in the [Sample Lab](https://github.com/GatorEducator/gatorgrader-samplelab) repository.
 
-NOTE: GatorGradle will automatically **NOT** install [Pipenv](pipenv.readthedocs.io). Nothing other then GatorGradle will be installed automatically.
+NOTE: GatorGradle will **NOT** automatically install [Pipenv](pipenv.readthedocs.io). Nothing other then GatorGradle will be installed automatically.
 
 To install Pipenv please follow [these](https://pipenv.readthedocs.io/en/latest/#install-pipenv-today) instructions.
 ## Configuring Checks


### PR DESCRIPTION
- Changed wording to represent current state
- Added link to Pipenv installation instructions

Fix: #22 