### PR TITLE
Remove pip dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ To run the plugin on a local gradle project, first run `gradle install` inside
 your cloned GatorGradle repository. Then, add the groovy code below to your
 local gradle project, replacing the `plugin` block.
 
-```
+```groovy
 buildscript{
   repositories {
     mavenLocal()

--- a/README.md
+++ b/README.md
@@ -17,17 +17,15 @@ gradle grade
 
 ## Installing Dependencies
 
-GatorGradle requires that [Git](https://git-scm.com/) and a version of [Python](https://www.python.org/)
-are installed -- it will automatically bootstrap a valid GatorGrader installation
-from there. Additionally, [Gradle](https://gradle.org/) is required to actually use
+GatorGradle requires that [Git](https://git-scm.com/), a version of
+[Python](https://www.python.org/) greater than 3.6, and
+[Pipenv](https://pipenv.readthedocs.io/en/latest) are installed -- it will
+automatically bootstrap a valid GatorGrader installation from there.
+Additionally, [Gradle](https://gradle.org/) is required to actually use
 GatorGradle. A complete example configuration of Gradle and GatorGradle is available
 in the [Sample Lab](https://github.com/GatorEducator/gatorgrader-samplelab) repository.
 
-NOTE: GatorGradle will **NOT** automatically install [Pipenv](https://pipenv.readthedocs.io/en/latest/);
-only GatorGrader is automatically installed. To install Pipenv manually please follow
-[these](https://pipenv.readthedocs.io/en/latest/#install-pipenv-today) instructions.
-
-NOTE: Other packages seemingly required: `python3-distutils`
+NOTE: GatorGradle will **ONLY** automatically install GatorGrader.
 
 ## Configuring Checks
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 artifact_name=org.gatored.gatorgradle
 artifact_group=org.gatored
 artifact_release=0.3
-artifact_patch=0
+artifact_patch=1

--- a/src/main/java/org/gatorgradle/internal/Dependency.java
+++ b/src/main/java/org/gatorgradle/internal/Dependency.java
@@ -1,3 +1,3 @@
 package org.gatorgradle.internal;
 
-public enum Dependency { GATORGRADER, GIT, PYTHON, PIPENV }
+public enum Dependency { GIT, PYTHON, PIPENV, GATORGRADER }

--- a/src/main/java/org/gatorgradle/internal/Dependency.java
+++ b/src/main/java/org/gatorgradle/internal/Dependency.java
@@ -1,3 +1,3 @@
 package org.gatorgradle.internal;
 
-public enum Dependency { GATORGRADER, GIT, PYTHON, PIP, PIPENV }
+public enum Dependency { GATORGRADER, GIT, PYTHON, PIPENV }

--- a/src/main/java/org/gatorgradle/internal/DependencyManager.java
+++ b/src/main/java/org/gatorgradle/internal/DependencyManager.java
@@ -56,8 +56,6 @@ public class DependencyManager {
         return doGatorGrader();
       case PYTHON:
         return doPython();
-      case PIP:
-        return doPip();
       case PIPENV:
         return doPipenv();
       case GIT:
@@ -98,16 +96,6 @@ public class DependencyManager {
     Console.log(
         "You must install Python 3! We recommend using Pyenv (https://github.com/pyenv/pyenv).");
     Console.log("You can also visit https://www.python.org/ to download Windows installers.");
-    return false;
-  }
-
-  private static boolean doPip() {
-    BasicCommand pip = new BasicCommand("pip", "-V").outputToSysOut(false);
-    pip.run();
-    if (pip.exitValue() == Command.SUCCESS) {
-      return true;
-    }
-    Console.log("You must install pip! We recommend using Pyenv (https://github.com/pyenv/pyenv).");
     return false;
   }
 

--- a/src/main/java/org/gatorgradle/task/GatorGradleTask.java
+++ b/src/main/java/org/gatorgradle/task/GatorGradleTask.java
@@ -93,20 +93,10 @@ public class GatorGradleTask extends DefaultTask {
   @TaskAction
   public void grade() {
     // ensure GatorGrader and dependencies are installed
-    if (!DependencyManager.installOrUpdate(Dependency.GIT)) {
-      throw new GradleException("Git not installed!");
-    }
-    if (!DependencyManager.installOrUpdate(Dependency.PYTHON)) {
-      throw new GradleException("Python not installed!");
-    }
-    if (!DependencyManager.installOrUpdate(Dependency.PIP)) {
-      throw new GradleException("Pip not installed!");
-    }
-    if (!DependencyManager.installOrUpdate(Dependency.PIPENV)) {
-      throw new GradleException("Pipenv not installed!");
-    }
-    if (!DependencyManager.installOrUpdate(Dependency.GATORGRADER)) {
-      throw new GradleException("GatorGrader not installed!");
+    for (Dependency dep : Dependency.values()) {
+      if (!DependencyManager.installOrUpdate(dep)) {
+        throw new GradleException(dep.name() + " not installed!");
+      }
     }
 
     // ensure we have a configuration


### PR DESCRIPTION
The pip dependency check is no longer needed. This PR additionally adds some documentation around dependency requirements, and increases the version to `0.3.1`.

**NOTE**: This patch will not apply to existing labs, only gradle projects which use version `0.3.1` after the merge has been made.