### PR TITLE
Fixes bug related to windows path separator

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 artifact_name=org.gatored.gatorgradle
 artifact_group=org.gatored
 artifact_release=0.3
-artifact_patch=1
+artifact_patch=2

--- a/src/main/java/org/gatorgradle/GatorGradlePlugin.java
+++ b/src/main/java/org/gatorgradle/GatorGradlePlugin.java
@@ -28,7 +28,7 @@ public class GatorGradlePlugin implements Plugin<Project> {
   public static final String OS;
 
   static {
-    F_SEP = System.getProperty("file.separator");
+    F_SEP = File.separator;
     USER_HOME = System.getProperty("user.home");
 
     String os = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -128,7 +128,9 @@ public class GatorGradleConfig implements Iterable<Command> {
       splits.add(mtc.group(1).replace("\"", ""));
     }
 
-    int sep = path.lastIndexOf(GatorGradlePlugin.F_SEP);
+    // FIXME: there should be a better method of determining which path separator is used
+    // in the config file -- it is independent of the OS.
+    int sep = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
     String name = path;
     String dir = "";
     if (sep >= 0) {

--- a/src/main/java/org/gatorgradle/internal/DependencyManager.java
+++ b/src/main/java/org/gatorgradle/internal/DependencyManager.java
@@ -15,7 +15,6 @@ import org.gatorgradle.util.Console;
 
 import org.gradle.api.GradleException;
 
-import static org.gatorgradle.GatorGradlePlugin.F_SEP;
 
 public class DependencyManager {
   public static final String GATORGRADER_GIT_REPO =
@@ -38,9 +37,11 @@ public class DependencyManager {
         throw new GradleException("Failed to run pipenv --venv! -- Was GatorGrader installed?");
       }
       if (GatorGradlePlugin.OS.equals(GatorGradlePlugin.WINDOWS)) {
-        PYTHON_EXECUTABLE = query.getOutput() + F_SEP + "Scripts" + F_SEP + "python";
+        PYTHON_EXECUTABLE = query.getOutput() + GatorGradlePlugin.F_SEP + "Scripts"
+            + GatorGradlePlugin.F_SEP + "python";
       } else {
-        PYTHON_EXECUTABLE = query.getOutput() + F_SEP + "bin" + F_SEP + "python";
+        PYTHON_EXECUTABLE = query.getOutput() + GatorGradlePlugin.F_SEP + "bin"
+            + GatorGradlePlugin.F_SEP + "python";
       }
     }
     return PYTHON_EXECUTABLE;

--- a/src/main/java/org/gatorgradle/internal/DependencyManager.java
+++ b/src/main/java/org/gatorgradle/internal/DependencyManager.java
@@ -15,6 +15,8 @@ import org.gatorgradle.util.Console;
 
 import org.gradle.api.GradleException;
 
+import static org.gatorgradle.GatorGradlePlugin.F_SEP;
+
 public class DependencyManager {
   public static final String GATORGRADER_GIT_REPO =
       "https://github.com/GatorEducator/gatorgrader.git";
@@ -36,9 +38,9 @@ public class DependencyManager {
         throw new GradleException("Failed to run pipenv --venv! -- Was GatorGrader installed?");
       }
       if (GatorGradlePlugin.OS.equals(GatorGradlePlugin.WINDOWS)) {
-        PYTHON_EXECUTABLE = query.getOutput() + "\\Scripts\\python";
+        PYTHON_EXECUTABLE = query.getOutput() + F_SEP + "Scripts" + F_SEP + "python";
       } else {
-        PYTHON_EXECUTABLE = query.getOutput() + "/bin/python";
+        PYTHON_EXECUTABLE = query.getOutput() + F_SEP + "bin" + F_SEP + "python";
       }
     }
     return PYTHON_EXECUTABLE;


### PR DESCRIPTION
This resulted from the fact that `GatorGradleConfig.java` looks for
the OS path separator in the config, thus requiring configuation
files on windows to use `\`, and linux `/`. This changes that to
just look for either `/` or `\`, interchangably.

The version is also bumped to `0.3.2`, and some other small related file separator changes were made.

THIS VERSION HAS NOT BEEN TESTED ON WINDOWS.