### PR TITLE
Add fix to ensure that GatorGrader is updated to the requested version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ before_install:
   # Install the Markdown linting tool called mdl
   - gem install mdl
   # Download the Gradle bin zip file
-  - wget https://services.gradle.org/distributions/gradle-4.9-bin.zip
-  - unzip -d $HOME gradle-4.9-bin.zip
+  - wget https://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+  - unzip -d $HOME gradle-5.4.1-bin.zip
   # Delete the downloaded zip file; probably don't need this but just to be sure
-  - rm -rf gradle-4.9-bin.zip
+  - rm -rf gradle-5.4.1-bin.zip
   # Add gradle bin to path at the beginning to ensure it overwrites old gradle
-  - export PATH="$HOME/gradle-4.9/bin:$PATH"
+  - export PATH="$HOME/gradle-5.4.1/bin:$PATH"
 
 # Step: Delete old files
 before_cache:

--- a/src/main/java/org/gatorgradle/internal/DependencyManager.java
+++ b/src/main/java/org/gatorgradle/internal/DependencyManager.java
@@ -187,7 +187,8 @@ public class DependencyManager {
     checkout.setWorkingDir(workingDir.toFile());
     checkout.outputToSysOut(false);
     checkout.run();
-    if (checkout.exitValue() != Command.SUCCESS && !checkout.getOutput().contains("You are not currently on a branch")) {
+    if (checkout.exitValue() != Command.SUCCESS
+        && !checkout.getOutput().contains("You are not currently on a branch")) {
       error("GatorGrader management failed, could update '" + revision + "'!", checkout);
       return false;
     }


### PR DESCRIPTION
This first fetches all changes, then attempts to checkout the requested version, then executes a pull while not failing for things that report "You are not currently on a branch".

This PR is a minor update that fixes a long-standing bug with the `version` tag in the front-matter `yml` configuration.