### PR TITLE
Upgrade `ru.vyarus.quality` version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "maven"
     id "java-gradle-plugin"
     id "com.gradle.plugin-publish" version "0.10.1"
-    id "ru.vyarus.quality" version "3.4.0"
+    id "ru.vyarus.quality" version "4.0.0"
 }
 
 group = "${artifact_group}"


### PR DESCRIPTION
This PR upgrades `ru.vyarus.quality` version to 4.0.0 to satisfy the latest Gradle 6.0.1

However, `WorkerExecutor.submit()` is a deprecated feature and will be incompatible with Gradle 7.0. This should be fixed soon.

```
gatorgradle/src/main/java/org/gatorgradle/task/GatorGradleGradeTask.java:79: warning: [deprecation] submit(Class<? extends Runnable>,Action<? super WorkerConfiguration>) in WorkerExecutor has been deprecated
        executor.submit(CommandExecutor.class, (conf) -> {
                ^
1 warning
```
