### PR TITLE
Change task dependency to mustRunAfter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ first store the endpoint and API key in environment variables with `GATOR_ENDPOI
 and `GATOR_API_KEY`, then use the `report` task, like so:
 
 ```bash
-gradle report
+gradle --continue grade report
 ```
 
 ## Installing Dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 artifact_name=org.gatored.gatorgradle
 artifact_group=org.gatored
-artifact_release=0.5
-artifact_patch=0
+artifact_release=0.7
+artifact_patch=1

--- a/src/main/java/org/gatorgradle/GatorGradlePlugin.java
+++ b/src/main/java/org/gatorgradle/GatorGradlePlugin.java
@@ -90,6 +90,6 @@ public class GatorGradlePlugin implements Plugin<Project> {
       task.setConfig(config);
       task.setWorkingDir(project.getProjectDir());
     });
-    reportTask.dependsOn(gradeTask);
+    reportTask.mustRunAfter(gradeTask);
   }
 }

--- a/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
+++ b/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
@@ -14,7 +14,7 @@ public class GatorGradleReportTask extends GatorGradleTask {
   @TaskAction
   public void report() {
     if (summary == null) {
-      throw new GradleException(StringUtil.color(StringUtil.BAD, "No report made! Try gradle --continue grade report"));
+      throw new GradleException(StringUtil.color(StringUtil.BAD, "Grading not run -- try gradle --continue grade report"));
     }
 
     summary.uploadOutputSummary();

--- a/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
+++ b/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
@@ -3,8 +3,8 @@ package org.gatorgradle.task;
 import org.gatorgradle.task.GatorGradleTask;
 import org.gatorgradle.util.StringUtil;
 
-import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.GradleException;
+import org.gradle.api.tasks.TaskAction;
 
 public class GatorGradleReportTask extends GatorGradleTask {
 

--- a/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
+++ b/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
@@ -3,6 +3,7 @@ package org.gatorgradle.task;
 import org.gatorgradle.task.GatorGradleTask;
 
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.GradleException;
 
 public class GatorGradleReportTask extends GatorGradleTask {
 
@@ -11,6 +12,10 @@ public class GatorGradleReportTask extends GatorGradleTask {
    */
   @TaskAction
   public void report() {
+    if (summary == null) {
+      throw new GradleException("No report made! Try gradle --continue grade report");
+    }
+
     summary.uploadOutputSummary();
   }
 }

--- a/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
+++ b/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
@@ -1,6 +1,7 @@
 package org.gatorgradle.task;
 
 import org.gatorgradle.task.GatorGradleTask;
+import org.gatorgradle.util.StringUtil;
 
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.GradleException;
@@ -13,7 +14,7 @@ public class GatorGradleReportTask extends GatorGradleTask {
   @TaskAction
   public void report() {
     if (summary == null) {
-      throw new GradleException("No report made! Try gradle --continue grade report");
+      throw new GradleException(StringUtil.color(StringUtil.BAD, "No report made! Try gradle --continue grade report"));
     }
 
     summary.uploadOutputSummary();

--- a/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
+++ b/src/main/java/org/gatorgradle/task/GatorGradleReportTask.java
@@ -14,7 +14,9 @@ public class GatorGradleReportTask extends GatorGradleTask {
   @TaskAction
   public void report() {
     if (summary == null) {
-      throw new GradleException(StringUtil.color(StringUtil.BAD, "Grading not run -- try gradle --continue grade report"));
+      throw new GradleException(
+          StringUtil.color(
+              StringUtil.BAD, "Grading not run -- try gradle --continue grade report"));
     }
 
     summary.uploadOutputSummary();


### PR DESCRIPTION
This changes the task dependency from `dependOn` to `mustRunAfter` due to the problem that it doesn't support the use of tag `--continue`, which continues the execution of tasks even if the previous one failed. In this case, to let `report` run even `grade` is not passed. The correct command `gradle --continue grade report`(the order of `grade` and `report` does not matter, `--continue` can also be put at the end of the command like this: `gradle grade report --continue`) is also updated in the `README`

This PR is a bugfix that fixes #68 