### PR TITLE
Add `idcommand` to handle user id collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ break: true
 fastfail: false
 # Specify an indentation level in spaces to be used in this file
 indent: 4
+# Should we collect user info from the environment variable?
+username-envvar: true
 # Specify a reference to checkout to in GatorGrader
 version: v0.2.0
 # Specify 'executables' that can be run as checks

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fastfail: false
 # Specify an indentation level in spaces to be used in this file
 indent: 4
 # Command to get user info/id
-# default as git user name
+# default as git config --global user.email
 idcommand: echo $TRAVIS_REPO_SLUG
 # Specify a reference to checkout to in GatorGrader
 version: v0.2.0

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ break: true
 fastfail: false
 # Specify an indentation level in spaces to be used in this file
 indent: 4
-# Should we collect user info from the environment variable?
-username-envvar: true
+# Command to get user info/id
+# default as git user name
+idcommand: echo $TRAVIS_REPO_SLUG
 # Specify a reference to checkout to in GatorGrader
 version: v0.2.0
 # Specify 'executables' that can be run as checks

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ fastfail: false
 # Specify an indentation level in spaces to be used in this file
 indent: 4
 # Command to get user info/id
-# default as git config --global user.email
+# default is 'git config --global user.email'
 idcommand: echo $TRAVIS_REPO_SLUG
 # Specify a reference to checkout to in GatorGrader
 version: v0.2.0

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -179,8 +179,6 @@ public class GatorGradleConfig implements Iterable<Command> {
     }
 
     if (file.hasHeader("idcommand")) {
-      // idCommand = makeCommand(null, file.getHeader("idcommand").asString(), true);
-      // System.out.println(idCommand);
       idCommand = file.getHeader("idcommand").asString();
     }
 

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -90,6 +90,7 @@ public class GatorGradleConfig implements Iterable<Command> {
    * @param breakBuild     should the build fail on check failures
    * @param fastBreakBuild should the build immediately fail on check failures
    * @param assignmentName the assignment name
+   * @param usernameEnvVar should the report get user info from env var
    * @param commands       the list of commands to run
    */
   public GatorGradleConfig(boolean breakBuild, boolean fastBreakBuild, String assignmentName,

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -59,7 +59,7 @@ public class GatorGradleConfig implements Iterable<Command> {
   private String gatorgraderRevision = "master";
   private String reportEndpoint = System.getenv("GATOR_ENDPOINT");
   private String reportApiKey = System.getenv("GATOR_API_KEY");
-  private Command idCommand = null;
+  private String idCommand = null;
   private String reflectionPath = null;
   private Collection<String> commandLineExecutables;
   private Command startupCommand = null;
@@ -196,7 +196,9 @@ public class GatorGradleConfig implements Iterable<Command> {
     }
 
     if (file.hasHeader("idcommand")) {
-      idCommand = makeCommand(null, file.getHeader("idcommand").asString(), true);
+      // idCommand = makeCommand(null, file.getHeader("idcommand").asString(), true);
+      // System.out.println(idCommand);
+      idCommand = file.getHeader("idcommand").asString();
     }
 
     if (file.hasHeader("revision")) {
@@ -275,7 +277,7 @@ public class GatorGradleConfig implements Iterable<Command> {
     return idCommand != null;
   }
 
-  public Command getIdCommand() {
+  public String getIdCommand() {
     return idCommand;
   }
 

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -59,7 +59,7 @@ public class GatorGradleConfig implements Iterable<Command> {
   private String gatorgraderRevision = "master";
   private String reportEndpoint = System.getenv("GATOR_ENDPOINT");
   private String reportApiKey = System.getenv("GATOR_API_KEY");
-  private String idCommand = null;
+  private String idCommand = "git config --global user.email";
   private String reflectionPath = null;
   private Collection<String> commandLineExecutables;
   private Command startupCommand = null;
@@ -252,10 +252,6 @@ public class GatorGradleConfig implements Iterable<Command> {
 
   public boolean shouldFastBreakBuild() {
     return fastBreakBuild;
-  }
-
-  public boolean hasIdCommand() {
-    return idCommand != null;
   }
 
   public String getIdCommand() {

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -196,7 +196,7 @@ public class GatorGradleConfig implements Iterable<Command> {
     }
 
     if (file.hasHeader("idCommand")) {
-      startupCommand = makeCommand(null, file.getHeader("startup").asString(), true);
+      idGeneratorCommand = makeCommand(null, file.getHeader("idCommand").asString(), true);
     }
 
     if (file.hasHeader("revision")) {
@@ -271,8 +271,12 @@ public class GatorGradleConfig implements Iterable<Command> {
     return fastBreakBuild;
   }
 
-  public boolean shouldUsernameEnvVar() {
-    return usernameEnvVar;
+  public boolean hasIdCommand() {
+    return idGeneratorCommand != null;
+  }
+
+  public Command getIdCommand() {
+    return idGeneratorCommand;
   }
 
   public String getAssignmentName() {

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -59,6 +59,7 @@ public class GatorGradleConfig implements Iterable<Command> {
   private String gatorgraderRevision = "master";
   private String reportEndpoint = System.getenv("GATOR_ENDPOINT");
   private String reportApiKey = System.getenv("GATOR_API_KEY");
+  private boolean usernameEnvVar = false;
   private String reflectionPath = null;
   private Collection<String> commandLineExecutables;
   private Command startupCommand = null;
@@ -92,11 +93,12 @@ public class GatorGradleConfig implements Iterable<Command> {
    * @param commands       the list of commands to run
    */
   public GatorGradleConfig(boolean breakBuild, boolean fastBreakBuild, String assignmentName,
-      Collection<Command> commands) {
+      boolean usernameEnvVar, Collection<Command> commands) {
     this();
     this.breakBuild = breakBuild;
     this.fastBreakBuild = fastBreakBuild;
     this.assignmentName = assignmentName;
+    this.usernameEnvVar = usernameEnvVar;
     this.gradingCommands = new HashSet<>(commands);
   }
 
@@ -194,6 +196,10 @@ public class GatorGradleConfig implements Iterable<Command> {
       fastBreakBuild = file.getHeader("fastfail").asBoolean();
     }
 
+    if (file.hasHeader("usernameEnvVar")) {
+      usernameEnvVar = file.getHeader("usernameEnvVar").asBoolean();
+    }
+
     if (file.hasHeader("revision")) {
       gatorgraderRevision = file.getHeader("revision").asString();
     } else if (file.hasHeader("version")) {
@@ -264,6 +270,10 @@ public class GatorGradleConfig implements Iterable<Command> {
 
   public boolean shouldFastBreakBuild() {
     return fastBreakBuild;
+  }
+
+  public boolean shouldUsernameEnvVar() {
+    return usernameEnvVar;
   }
 
   public String getAssignmentName() {

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -197,8 +197,8 @@ public class GatorGradleConfig implements Iterable<Command> {
       fastBreakBuild = file.getHeader("fastfail").asBoolean();
     }
 
-    if (file.hasHeader("usernameEnvVar")) {
-      usernameEnvVar = file.getHeader("usernameEnvVar").asBoolean();
+    if (file.hasHeader("username-envvar")) {
+      usernameEnvVar = file.getHeader("username-envvar").asBoolean();
     }
 
     if (file.hasHeader("revision")) {

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -85,23 +85,6 @@ public class GatorGradleConfig implements Iterable<Command> {
   }
 
   /**
-   * Create a config that will use the given values.
-   *
-   * @param breakBuild     should the build fail on check failures
-   * @param fastBreakBuild should the build immediately fail on check failures
-   * @param assignmentName the assignment name
-   * @param commands       the list of commands to run
-   */
-  public GatorGradleConfig(boolean breakBuild, boolean fastBreakBuild, String assignmentName,
-      Collection<Command> commands) {
-    this();
-    this.breakBuild = breakBuild;
-    this.fastBreakBuild = fastBreakBuild;
-    this.assignmentName = assignmentName;
-    this.gradingCommands = new HashSet<>(commands);
-  }
-
-  /**
    * Utility method to convert a line of text to a Command.
    *
    * @param  path the path in the config file this line is in the context of

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -59,7 +59,7 @@ public class GatorGradleConfig implements Iterable<Command> {
   private String gatorgraderRevision = "master";
   private String reportEndpoint = System.getenv("GATOR_ENDPOINT");
   private String reportApiKey = System.getenv("GATOR_API_KEY");
-  private Command idGeneratorCommand = null;
+  private Command idCommand = null;
   private String reflectionPath = null;
   private Collection<String> commandLineExecutables;
   private Command startupCommand = null;
@@ -195,8 +195,8 @@ public class GatorGradleConfig implements Iterable<Command> {
       fastBreakBuild = file.getHeader("fastfail").asBoolean();
     }
 
-    if (file.hasHeader("idCommand")) {
-      idGeneratorCommand = makeCommand(null, file.getHeader("idCommand").asString(), true);
+    if (file.hasHeader("idcommand")) {
+      idCommand = makeCommand(null, file.getHeader("idcommand").asString(), true);
     }
 
     if (file.hasHeader("revision")) {
@@ -272,11 +272,11 @@ public class GatorGradleConfig implements Iterable<Command> {
   }
 
   public boolean hasIdCommand() {
-    return idGeneratorCommand != null;
+    return idCommand != null;
   }
 
   public Command getIdCommand() {
-    return idGeneratorCommand;
+    return idCommand;
   }
 
   public String getAssignmentName() {

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -180,6 +180,8 @@ public class GatorGradleConfig implements Iterable<Command> {
 
     if (file.hasHeader("idcommand")) {
       idCommand = file.getHeader("idcommand").asString();
+    } else if (file.hasHeader("idcmd")) {
+      idCommand = file.getHeader("idcmd").asString();
     }
 
     if (file.hasHeader("revision")) {

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -59,7 +59,7 @@ public class GatorGradleConfig implements Iterable<Command> {
   private String gatorgraderRevision = "master";
   private String reportEndpoint = System.getenv("GATOR_ENDPOINT");
   private String reportApiKey = System.getenv("GATOR_API_KEY");
-  private boolean usernameEnvVar = false;
+  private Command idGeneratorCommand = null;
   private String reflectionPath = null;
   private Collection<String> commandLineExecutables;
   private Command startupCommand = null;
@@ -90,16 +90,14 @@ public class GatorGradleConfig implements Iterable<Command> {
    * @param breakBuild     should the build fail on check failures
    * @param fastBreakBuild should the build immediately fail on check failures
    * @param assignmentName the assignment name
-   * @param usernameEnvVar should the report get user info from env var
    * @param commands       the list of commands to run
    */
   public GatorGradleConfig(boolean breakBuild, boolean fastBreakBuild, String assignmentName,
-      boolean usernameEnvVar, Collection<Command> commands) {
+      Collection<Command> commands) {
     this();
     this.breakBuild = breakBuild;
     this.fastBreakBuild = fastBreakBuild;
     this.assignmentName = assignmentName;
-    this.usernameEnvVar = usernameEnvVar;
     this.gradingCommands = new HashSet<>(commands);
   }
 
@@ -197,8 +195,8 @@ public class GatorGradleConfig implements Iterable<Command> {
       fastBreakBuild = file.getHeader("fastfail").asBoolean();
     }
 
-    if (file.hasHeader("username-envvar")) {
-      usernameEnvVar = file.getHeader("username-envvar").asBoolean();
+    if (file.hasHeader("idCommand")) {
+      startupCommand = makeCommand(null, file.getHeader("startup").asString(), true);
     }
 
     if (file.hasHeader("revision")) {

--- a/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
+++ b/src/main/java/org/gatorgradle/config/GatorGradleConfig.java
@@ -23,7 +23,7 @@ import org.gradle.api.GradleException;
  * GatorGradleConfig holds the configuration for this assignment.
  * TODO: make this configurable via DSL blocks in build.gradle
  */
-public class GatorGradleConfig implements Iterable<Command> {
+public final class GatorGradleConfig implements Iterable<Command> {
 
   private static GatorGradleConfig singleton;
 

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -15,7 +15,6 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -118,7 +118,7 @@ public class CommandOutputSummary {
 
     if (GatorGradleConfig.get().hasIdCommand() == true) {
       BasicCommand getUserId = (BasicCommand) GatorGradleConfig.get().getIdCommand();
-      getUserId.run()
+      getUserId.run();
       if (getUserId.exitValue() == Command.SUCCESS) {
         userId = getUserId.getOutput().trim();
       }

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -7,6 +7,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.UnknownHostException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -130,8 +131,11 @@ public class CommandOutputSummary {
     if (getUserId.exitValue() == Command.SUCCESS) {
       userId = getUserId.getOutput().trim();
     } else {
-      // Get Host Name
-      userId = InetAddress.getLocalHost().getHostName();
+      try {
+        userId = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException ex) {
+        log.error("Exception while getting local host name: {}", ex.toString());
+      }
     }
 
     builder.append("\"userId\":");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -128,7 +128,7 @@ public class CommandOutputSummary {
     if (getUserId.exitValue() == Command.SUCCESS) {
       userId = getUserId.getOutput().trim();
     } else {
-      log.error("No user information collected, not uploading results.");
+      log.error("ERROR: User ID command failed, not uploading results.");
       return;
     }
 

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -157,7 +157,9 @@ public class CommandOutputSummary {
         )
       );
     } catch (IOException ex) {
-      log.error("Failed to read {}, not uploading results.", GatorGradleConfig.get().getReflectionPath());
+      log.error(
+          "Failed to read {}, not uploading results.",
+          GatorGradleConfig.get().getReflectionPath());
       throw new GradleException("Exception while reading reflection file", ex);
     }
     builder.append("\"").append(reflection).append("\"").append(",");
@@ -235,8 +237,8 @@ public class CommandOutputSummary {
       }
 
     } catch (MalformedURLException ex) {
-      log.error("Failed to upload data; report endpoint specified in configuration is malformed.");
-      throw new GradleException("Failed to upload data; report endpoint specified in configuration is malformed");
+      log.error("Failed to upload data; configured report endpoint is malformed.");
+      throw new GradleException("Failed to upload data; configured report endpoint is malformed");
     } catch (IOException ex) {
       log.error("Exception while uploading check data: {}", ex.toString());
       throw new GradleException("Exception while uploading check data", ex);

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -117,7 +117,8 @@ public class CommandOutputSummary {
     String userId = "unknown";
 
     if (GatorGradleConfig.get().hasIdCommand() == true) {
-      BasicCommand getUserId = (BasicCommand) GatorGradleConfig.get().getIdCommand();
+      BasicCommand getUserId = new BasicCommand("sh", "-c", GatorGradleConfig.get().getIdCommand());
+      getUserId.outputToSysOut(true);
       getUserId.run();
       if (getUserId.exitValue() == Command.SUCCESS) {
         userId = getUserId.getOutput().trim();
@@ -185,6 +186,8 @@ public class CommandOutputSummary {
     builder.append("}");
 
     String resultListJson = builder.toString();
+
+    System.out.println(resultListJson);
 
     log.info("Result JSON: {}", resultListJson);
 

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -113,7 +113,7 @@ public class CommandOutputSummary {
    */
   public void uploadOutputSummary(List<CheckResult> failed, List<CheckResult> all) {
     StringBuilder builder = new StringBuilder();
-    builder.append("{");
+    builder.append('{');
 
     String userId;
     BasicCommand getUserId = null;
@@ -133,14 +133,14 @@ public class CommandOutputSummary {
     }
 
     builder.append("\"userId\":");
-    builder.append("\"").append(userId).append("\"").append(",");
+    builder.append('\"').append(userId).append('\"').append(',');
 
     builder.append("\"time\":");
-    builder.append("\"").append(Instant.now()).append("\"").append(",");
+    builder.append('\"').append(Instant.now()).append('\"').append(',');
 
     builder.append("\"assignment\":");
-    builder.append("\"").append(GatorGradleConfig.get().getAssignmentName());
-    builder.append("\"").append(",");
+    builder.append('\"').append(GatorGradleConfig.get().getAssignmentName());
+    builder.append('\"').append(',');
 
     // reflection
     builder.append("\"reflection\":");
@@ -162,19 +162,19 @@ public class CommandOutputSummary {
           GatorGradleConfig.get().getReflectionPath());
       throw new GradleException("Exception while reading reflection file", ex);
     }
-    builder.append("\"").append(reflection).append("\"").append(",");
+    builder.append('\"').append(reflection).append('\"').append(',');
     // end reflection
 
     // report
     builder.append("\"report\":{");
 
     builder.append("\"numberOfChecks\":");
-    builder.append(Integer.toString(all.size())).append(",");
+    builder.append(Integer.toString(all.size())).append(',');
 
     builder.append("\"numberOfFailures\":");
-    builder.append(Integer.toString(failed.size())).append(",");
+    builder.append(Integer.toString(failed.size())).append(',');
 
-    builder.append("\"results\":").append("[");
+    builder.append("\"results\":").append('[');
     builder.append(
         String.join(
           ",",
@@ -182,10 +182,10 @@ public class CommandOutputSummary {
           .collect(Collectors.toList())
         )
     );
-    builder.append("]").append("}");
+    builder.append(']').append('}');
     // end report
 
-    builder.append("}");
+    builder.append('}');
 
     String resultListJson = builder.toString();
 

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -21,6 +21,7 @@ import org.gatorgradle.command.BasicCommand;
 import org.gatorgradle.command.Command;
 import org.gatorgradle.command.GatorGraderCommand;
 import org.gatorgradle.config.GatorGradleConfig;
+import org.gatorgradle.GatorGradlePlugin;
 import org.gatorgradle.util.StringUtil;
 
 import org.gradle.api.GradleException;
@@ -117,7 +118,7 @@ public class CommandOutputSummary {
 
     String userId = "unknown";
     BasicCommand getUserId = null;
-    if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).equals("windows")) {
+    if (GatorGradlePlugin.OS.equals(GatorGradlePlugin.WINDOWS)) {
       getUserId = new BasicCommand(
           "sh", "/C", GatorGradleConfig.get().getIdCommand());
     } else {
@@ -128,8 +129,6 @@ public class CommandOutputSummary {
     if (getUserId.exitValue() == Command.SUCCESS) {
       userId = getUserId.getOutput().trim();
     }
-
-
 
     builder.append("\"userId\":");
     builder.append("\"").append(userId).append("\"").append(",");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -128,6 +129,9 @@ public class CommandOutputSummary {
     getUserId.run();
     if (getUserId.exitValue() == Command.SUCCESS) {
       userId = getUserId.getOutput().trim();
+    } else {
+      // Get Host Name
+      userId = InetAddress.getLocalHost().getHostName();
     }
 
     builder.append("\"userId\":");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -195,8 +195,6 @@ public class CommandOutputSummary {
 
     String resultListJson = builder.toString();
 
-    System.out.println(resultListJson);
-
     log.info("Result JSON: {}", resultListJson);
 
     HttpURLConnection con = null;

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -5,10 +5,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -130,11 +128,7 @@ public class CommandOutputSummary {
     if (getUserId.exitValue() == Command.SUCCESS) {
       userId = getUserId.getOutput().trim();
     } else {
-      try {
-        userId = InetAddress.getLocalHost().getHostName();
-      } catch (UnknownHostException ex) {
-        log.error("Exception while getting local host name: {}", ex.toString());
-      }
+      log.error("Exception while collecting user info");
     }
 
     builder.append("\"userId\":");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -7,8 +7,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
-import java.net.UnknownHostException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -19,11 +19,11 @@ import java.util.Locale;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 
+import org.gatorgradle.GatorGradlePlugin;
 import org.gatorgradle.command.BasicCommand;
 import org.gatorgradle.command.Command;
 import org.gatorgradle.command.GatorGraderCommand;
 import org.gatorgradle.config.GatorGradleConfig;
-import org.gatorgradle.GatorGradlePlugin;
 import org.gatorgradle.util.StringUtil;
 
 import org.gradle.api.GradleException;

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -13,6 +13,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 
@@ -117,7 +118,13 @@ public class CommandOutputSummary {
     String userId = "unknown";
 
     if (GatorGradleConfig.get().hasIdCommand() == true) {
-      BasicCommand getUserId = new BasicCommand("sh", "-c", GatorGradleConfig.get().getIdCommand());
+      if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH) == "windows") {
+        BasicCommand getUserId = new BasicCommand(
+            "sh", "/C", GatorGradleConfig.get().getIdCommand());
+      } else {
+        BasicCommand getUserId = new BasicCommand(
+            "sh", "-c", GatorGradleConfig.get().getIdCommand());
+      }
       getUserId.outputToSysOut(true);
       getUserId.run();
       if (getUserId.exitValue() == Command.SUCCESS) {

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -126,7 +126,6 @@ public class CommandOutputSummary {
         getUserId = new BasicCommand(
             "sh", "-c", GatorGradleConfig.get().getIdCommand());
       }
-      getUserId.outputToSysOut(true);
       getUserId.run();
       if (getUserId.exitValue() == Command.SUCCESS) {
         userId = getUserId.getOutput().trim();

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -164,8 +164,8 @@ public class CommandOutputSummary {
           )
 
       );
-    } catch (IOException exception) {
-      exception.printStackTrace();
+    } catch (IOException ex) {
+      log.error("Exception while reading reflection file: {}", ex.toString());
     }
     builder.append("\"").append(",");
     // end reflection

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -118,11 +118,12 @@ public class CommandOutputSummary {
     String userId = "unknown";
 
     if (GatorGradleConfig.get().hasIdCommand() == true) {
+      BasicCommand getUserId = null;
       if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH) == "windows") {
-        BasicCommand getUserId = new BasicCommand(
+        getUserId = new BasicCommand(
             "sh", "/C", GatorGradleConfig.get().getIdCommand());
       } else {
-        BasicCommand getUserId = new BasicCommand(
+        getUserId = new BasicCommand(
             "sh", "-c", GatorGradleConfig.get().getIdCommand());
       }
       getUserId.outputToSysOut(true);

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -114,16 +114,22 @@ public class CommandOutputSummary {
     StringBuilder builder = new StringBuilder();
     builder.append("{");
 
-    String userID = "unknown";
+    String userInfo = "unknown";
     String userAttribute = "unknown";
-    BasicCommand getGitUser = new BasicCommand("git", "config", "--global", "user.email");
-    getGitUser.run();
-    if (getGitUser.exitValue() == Command.SUCCESS) {
-      userID = getGitUser.getOutput().trim();
+    if (GatorGradleConfig.get().shouldUsernameEnvVar() == true) {
+      userInfo = System.getenv("TRAVIS_REPO_SLUG");
+      userAttribute = "repo";
+    } else {
+      BasicCommand getGitUser = new BasicCommand("git", "config", "--global", "user.email");
+      getGitUser.run();
+      if (getGitUser.exitValue() == Command.SUCCESS) {
+        userInfo = getGitUser.getOutput().trim();
+      }
+      userAttribute = "user";
     }
 
-    builder.append("\"user\":");
-    builder.append("\"").append(userID).append("\"").append(",");
+    builder.append("\"" + userAttribute + "\":");
+    builder.append("\"").append(userInfo).append("\"").append(",");
 
     builder.append("\"time\":");
     builder.append("\"").append(Instant.now()).append("\"").append(",");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -114,22 +114,24 @@ public class CommandOutputSummary {
     StringBuilder builder = new StringBuilder();
     builder.append("{");
 
-    String userInfo = "unknown";
-    String userAttribute = "unknown";
-    if (GatorGradleConfig.get().shouldUsernameEnvVar() == true) {
-      userInfo = System.getenv("TRAVIS_REPO_SLUG");
-      userAttribute = "repo";
+    String userId = "unknown";
+
+    if (GatorGradleConfig.get().hasIdCommand() == true) {
+      BasicCommand getUserId = (BasicCommand) GatorGradleConfig.get().getIdCommand();
+      getUserId.run()
+      if (getUserId.exitValue() == Command.SUCCESS) {
+        userId = getUserId.getOutput().trim();
+      }
     } else {
       BasicCommand getGitUser = new BasicCommand("git", "config", "--global", "user.email");
       getGitUser.run();
       if (getGitUser.exitValue() == Command.SUCCESS) {
-        userInfo = getGitUser.getOutput().trim();
+        userId = getGitUser.getOutput().trim();
       }
-      userAttribute = "user";
     }
 
-    builder.append("\"" + userAttribute + "\":");
-    builder.append("\"").append(userInfo).append("\"").append(",");
+    builder.append("\"userId\":");
+    builder.append("\"").append(userId).append("\"").append(",");
 
     builder.append("\"time\":");
     builder.append("\"").append(Instant.now()).append("\"").append(",");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -114,15 +114,16 @@ public class CommandOutputSummary {
     StringBuilder builder = new StringBuilder();
     builder.append("{");
 
-    String userEmail = "unknown";
+    String userID = "unknown";
+    String userAttribute = "unknown";
     BasicCommand getGitUser = new BasicCommand("git", "config", "--global", "user.email");
     getGitUser.run();
     if (getGitUser.exitValue() == Command.SUCCESS) {
-      userEmail = getGitUser.getOutput().trim();
+      userID = getGitUser.getOutput().trim();
     }
 
     builder.append("\"user\":");
-    builder.append("\"").append(userEmail).append("\"").append(",");
+    builder.append("\"").append(userID).append("\"").append(",");
 
     builder.append("\"time\":");
     builder.append("\"").append(Instant.now()).append("\"").append(",");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -128,7 +128,8 @@ public class CommandOutputSummary {
     if (getUserId.exitValue() == Command.SUCCESS) {
       userId = getUserId.getOutput().trim();
     } else {
-      log.error("Exception while collecting user info");
+      log.error("No user information collected, not uploading results.");
+      return;
     }
 
     builder.append("\"userId\":");

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -119,7 +119,7 @@ public class CommandOutputSummary {
 
     if (GatorGradleConfig.get().hasIdCommand() == true) {
       BasicCommand getUserId = null;
-      if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH) == "windows") {
+      if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).equals("windows")) {
         getUserId = new BasicCommand(
             "sh", "/C", GatorGradleConfig.get().getIdCommand());
       } else {

--- a/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
+++ b/src/main/java/org/gatorgradle/display/CommandOutputSummary.java
@@ -116,27 +116,20 @@ public class CommandOutputSummary {
     builder.append("{");
 
     String userId = "unknown";
-
-    if (GatorGradleConfig.get().hasIdCommand() == true) {
-      BasicCommand getUserId = null;
-      if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).equals("windows")) {
-        getUserId = new BasicCommand(
-            "sh", "/C", GatorGradleConfig.get().getIdCommand());
-      } else {
-        getUserId = new BasicCommand(
-            "sh", "-c", GatorGradleConfig.get().getIdCommand());
-      }
-      getUserId.run();
-      if (getUserId.exitValue() == Command.SUCCESS) {
-        userId = getUserId.getOutput().trim();
-      }
+    BasicCommand getUserId = null;
+    if (System.getProperty("os.name").toLowerCase(Locale.ENGLISH).equals("windows")) {
+      getUserId = new BasicCommand(
+          "sh", "/C", GatorGradleConfig.get().getIdCommand());
     } else {
-      BasicCommand getGitUser = new BasicCommand("git", "config", "--global", "user.email");
-      getGitUser.run();
-      if (getGitUser.exitValue() == Command.SUCCESS) {
-        userId = getGitUser.getOutput().trim();
-      }
+      getUserId = new BasicCommand(
+          "sh", "-c", GatorGradleConfig.get().getIdCommand());
     }
+    getUserId.run();
+    if (getUserId.exitValue() == Command.SUCCESS) {
+      userId = getUserId.getOutput().trim();
+    }
+
+
 
     builder.append("\"userId\":");
     builder.append("\"").append(userId).append("\"").append(",");


### PR DESCRIPTION
This PR adds an option to collect user info from a command in the config file. The user can determine it by adding the header `idcommand: <command>` to the config file.

This PR is a small update that fixes #67 