### PR TITLE
Fix #73 by updating use of WorkerExecutor

### DIFF
--- a/src/main/java/org/gatorgradle/task/GatorGradleGradeTask.java
+++ b/src/main/java/org/gatorgradle/task/GatorGradleGradeTask.java
@@ -11,7 +11,6 @@ import org.gatorgradle.util.Console;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.workers.IsolationMode;
 import org.gradle.workers.WorkerExecutor;
 
 public class GatorGradleGradeTask extends GatorGradleTask {
@@ -73,8 +72,7 @@ public class GatorGradleGradeTask extends GatorGradleTask {
         }
 
         // configure command executor
-        executor.submit(CommandExecutor.class, (conf) -> {
-          conf.setIsolationMode(IsolationMode.NONE);
+        executor.noIsolation().submit(CommandExecutor.class, (conf) -> {
           conf.setDisplayName(cmd.toString());
           conf.setParams(cmd);
         });


### PR DESCRIPTION
This simple change should enable use in Gradle versions 8 and beyond, and remove warnings present in Gradle 7.

The change follows exactly the solution laid out in issue #73: adding the `noIsolation()` builder method to the `executor.submit` line.

This PR is a bugfix that fixes #73.