### PR TITLE
Fix contributing markdown

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,10 +68,9 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor
+Covenant](https://www.contributor-covenant.org), version 1.4, available
+[here](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).
 
-[homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+For answers to common questions about this code of conduct, see the
+[FAQ](https://www.contributor-covenant.org/faq).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ Model](https://guides.github.com/introduction/flow/) to guide our engineering of
 this tool and we invite you to also follow it as you make a contribution. If you
 have a new feature or bug fix that you want the project maintainers to merge
 into GatorGradle, then you should make a [pull
-request](https://github.com/GatorEducator/gatorgradle/pulls) against the `develop` branch. Please follow the
-provided template when you are describing your pull request, bearing in mind
-that the project maintainers will not merge any pull requests that either do not
-adhere to the template or break any aspects of the automated build.
+request](https://github.com/GatorEducator/gatorgradle/pulls) against the
+`develop` branch. Please follow the provided template when you are describing
+your pull request, bearing in mind that the project maintainers will not merge
+any pull requests that either do not adhere to the template or break any aspects
+of the automated build.


### PR DESCRIPTION
This PR adds some minor wording changes and fixes bare links and line length issues in `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`.

This PR also completely fixes #42.